### PR TITLE
adição de arquvios

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,27 @@ Um par de fone de ouvido, a sua lista de reprodução favorita e pronto: você e
 <img width="552" alt="image" src="https://github.com/user-attachments/assets/9873181b-511f-42d9-8cf5-5d5966515634" />
 
 
-# Equipe: <nome-da-equipe>
-1. <Nome de fulano>
-2. <Nome de fulana>
+# Equipe: <Next Stage>
+1. <Erick Barbosa de Araújo Silva> - erickkaraujo16@gmail.com
+2. Gustavo Ferreira Rigaud - gustavorigaud005@gmail.com
+3. Eduardo Silva Brandão Filho - edufilhogm@gmail.com
+4. Felipe Loureiro Souza  - felipelipesouza24@gmail.com
+5. Antônio Pedro Roriz de Sousa - pedrororiz41@gmail.com
+6. Rafik Dórea - rafikdorea10@outlook.com
+
+
+Considerações sobre o trabalho: 
+1. Para que as músicas sejam adicionadas corretamente no repositório, o usuário deve informar exatamente o local que o arquivo está ex: C:\Users\erick\Downloads\musica.wav
+2. Pode ser que na reprodução da lista de reprodução ao passar ou voltar uma música, seja necessário reiniciar a lista de reprodução para que os comandos funcionem, tentamos corrigir isso mas não conseguimos, porém depois de reiniciar a lista, os comandos funcionam normalmente.
+3. O código está com descrições propositais nas classes e variáveis para evitar dúvidas.
+
+Avaliação:
+| Avaliador \ Avaliado |   Erick   |  Gustavo  |  Eduardo  | Antônio Pedro |  Felipe   |   Rafik   |
+|----------------------|-----------|-----------|-----------|----------------|-----------|-----------|
+|        Erick         |           |           |           |                |           |           |
+|       Gustavo        |           |           |           |                |           |           |
+|       Eduardo        |           |           |           |                |           |           |
+|    Antônio Pedro     |           |           |           |                |           |           |
+|        Felipe        |           |           |           |                |           |           |
+|        Rafik         |           |           |           |                |           |           |
+


### PR DESCRIPTION
MangaController.java  
- Método reproduzirListaDeReproducao revisado para exibir menu de controle de reprodução dentro de um loop  
- Menu de controle com opções numeradas para pausar, voltar, passar, reiniciar e parar lista  
- Uso de Scanner dentro do controller para ler escolhas do usuário  
- Padronização do helper buscarListaPorTitulo para encontrar listas  

 MangaSoundApplication.java  
- Inserida opção 3 Adicionar Musica a Lista de Reprodução no menu principal  
- Removida chamada duplicada de controle de reprodução da aplicação principal  
- Variável opcao inicializada como zero para evitar warning de não inicialização  